### PR TITLE
Fix for lost privilages at fakeusb folder

### DIFF
--- a/fakeusb-AccessPrivilageReseter/Makefile
+++ b/fakeusb-AccessPrivilageReseter/Makefile
@@ -1,0 +1,14 @@
+all: payload.bin
+
+clean:
+	rm -f payload.elf payload.bin
+
+../lib/lib.a:
+	cd ../lib; make
+
+payload.elf: ../lib/lib.a main.c
+	gcc -isystem ../freebsd-headers -nostdinc -nostdlib -fno-stack-protector -static ../lib/lib.a main.c -Wl,-gc-sections -o payload.elf -fPIE -ffreestanding
+
+payload.bin: payload.elf
+	objcopy payload.elf --only-section .text --only-section .data --only-section .bss --only-section .rodata -O binary payload.bin
+	file payload.bin | fgrep -q 'payload.bin: DOS executable (COM)'

--- a/fakeusb-AccessPrivilageReseter/main.c
+++ b/fakeusb-AccessPrivilageReseter/main.c
@@ -1,0 +1,11 @@
+#include <unistd.h>
+#include <stdio.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <signal.h>
+
+int main()
+{
+    chmod("/user/home/fakeusb", 0777);
+    return 0;
+}


### PR DESCRIPTION
Sometimes "fakeusb" folder change priviliages to "dr-sr-sr-s", to solve this issue I create simply code, which only changes again privilages of "fakeusb" folder to "drwsrwsrws".